### PR TITLE
Implement deviations to rfc6486, rfc6487 and rfc6488

### DIFF
--- a/rpkimancer_sig/conjure.py
+++ b/rpkimancer_sig/conjure.py
@@ -23,14 +23,15 @@ from rpkimancer.cli import Args
 from rpkimancer.cli.conjure import (ConjurePlugin,
                                     DEFAULT_CA_AS_RESOURCES,
                                     DEFAULT_CA_IP_RESOURCES,
-                                    META_AS, META_IP, META_PATH)
-
-from .sigobj import SignedChecklist
+                                    META_AS, META_IP, META_PATH,
+                                    PluginReturn)
 
 if typing.TYPE_CHECKING:
     from rpkimancer.cert import CertificateAuthority
 
 log = logging.getLogger(__name__)
+
+RSC_SUB_DIR = "sigs"
 
 
 class ConjureChecklist(ConjurePlugin):
@@ -64,11 +65,14 @@ class ConjureChecklist(ConjurePlugin):
             parsed_args: Args,
             ca: CertificateAuthority,
             *args: typing.Any,
-            **kwargs: typing.Any) -> None:
+            **kwargs: typing.Any) -> PluginReturn:
         """Run with the given arguments."""
         # create RSC object
+        from .sigobj import SignedChecklist
         log.info("creating signed checklist object")
+        rsc_output_dir = os.path.join(parsed_args.output_dir, RSC_SUB_DIR)
         SignedChecklist(issuer=ca,
                         paths=parsed_args.rsc_paths,
                         as_resources=parsed_args.rsc_as_resources,
                         ip_resources=parsed_args.rsc_ip_resources)
+        return {"rsc_output_dir": rsc_output_dir}

--- a/rpkimancer_sig/eecert.py
+++ b/rpkimancer_sig/eecert.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2021 Ben Maddison. All rights reserved.
+#
+# The contents of this file are licensed under the MIT License
+# (the "License"); you may not use this file except in compliance with the
+# License.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+"""RPKI Signed Checklist implementation - draft-ietf-sidrops-rpki-rsc."""
+
+from __future__ import annotations
+
+import logging
+
+from rpkimancer.cert import EECertificate
+
+log = logging.getLogger(__name__)
+
+
+class UnpublishedEECertificate(EECertificate):
+    """RPKI Unpublished EE Certificate."""
+
+    sia = None
+    mft_entry = None

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -49,8 +49,7 @@ class TestCli:
     def test_perceive(self, target_directory, fmt):
         """Test the perceive subcommand."""
         from rpkimancer.cli.__main__ import main
-        repo_path = target_directory.join("repo")
-        pattern = os.path.join(str(repo_path), "**", "*.sig")
+        pattern = os.path.join(str(target_directory), "**", "*.sig")
         paths = glob.glob(pattern, recursive=True)
         argv = ["perceive",
                 "--signed-data",


### PR DESCRIPTION
- exclude object from issuing CA's manifest
- omit SIA extension from EE cert
- publish outside issuing CA's repo path
