### PR TITLE
register CONTENT-TYPE for DER codec

### DIFF
--- a/rpkimancer_sig/sigobj.py
+++ b/rpkimancer_sig/sigobj.py
@@ -93,7 +93,8 @@ class SignedChecklistEContent(EncapsulatedContent):
         return self._ip_resources
 
 
-class SignedChecklist(SignedObject):
+class SignedChecklist(SignedObject,
+                      econtent_type=RpkiSignedChecklist_2021.ct_rpkiSignedChecklist):  # noqa: E501
     """CMS ASN.1 ContentInfo for RPKI Signed Checklists."""
 
     econtent_cls = SignedChecklistEContent


### PR DESCRIPTION
`rpkimancer` now supports augmenting object information sets used in open-type
definitions at runtime.

In practise, this means that Signed Object modules that define a `CONTENT-TYPE`
instance for use in the `SignedData.encapContentInfo` component of the CMS
structure can now get encoded/decoded directly with no additional boilerplate.

The registration of the `CONTENT-TYPE` instance is done via a hook when
`rpkimancer.sigobj.base.SignedObject` is subclassed.

This PR updates the rpkimancer-sig plugin to take advantage of this feature.
